### PR TITLE
app-2: declare a [skin] contract (fixes the banding class at the source)

### DIFF
--- a/archival_template.toml
+++ b/archival_template.toml
@@ -18,3 +18,103 @@ keep_objects = [
     "terms_of_service",
     "privacy_policy"
 ]
+
+# ---------------------------------------------------------------------------
+# Skin contract
+# ---------------------------------------------------------------------------
+# Declares what an automated skin pass may change, and what it must not.
+#
+# Motivation: the lead-gen skin pass (aider, via `archival-utility preview
+# generate`) has unrestricted write access to this stylesheet. In the journal/US
+# batch it desynchronised the three variables that encode ONE colour below,
+# producing a visible banding stripe under the hero on 2 of 5 generated sites.
+# Nothing in the pipeline caught it before those sites were built and
+# screenshotted for outreach.
+#
+# Anything NOT listed in [skin.variables] is immutable to a skin pass.
+
+[skin]
+files = ["public/styles.css"]
+selector = ":root"
+
+# Variables a skin may set freely.
+[skin.variables]
+"--color-text" = { type = "color" }
+# NOTE: --color-background is dual-role. It is the page surface AND the text
+# colour on --color-button-bg (see .skip-link, .support-modules .module a,
+# .not-found-cta). The contrast rule below covers that second role.
+"--color-background" = { type = "color" }
+"--color-heading" = { type = "color" }
+"--color-footer-text" = { type = "color" }
+"--color-supplement" = { type = "color" }
+# The "ink" colour: button fill, link text, and (via the derive below) the hero
+# button fill and headline. Confirmed by Alex as ONE intentional colour, not a
+# coincidence of the stock black-and-white palette.
+"--color-button-bg" = { type = "color" }
+"--typo-h1-size" = { type = "length", min = "3rem", max = "8rem" }
+"--typo-h1-weight" = { type = "number", min = 400, max = 900 }
+"--typo-h2-size" = { type = "length", min = "2rem", max = "8rem" }
+"--typo-body-size" = { type = "length", min = "1rem", max = "1.75rem" }
+
+# Computed from their source — never authored by a skin.
+#
+# `header.hero` here has no fixed height and only 2.5rem margin-bottom: it is a
+# CONTINUOUS PAGE SURFACE with body, not a distinct band. (Contrast app-1, whose
+# hero is a deliberate 43rem fixed block and therefore correctly has NO such
+# derive.) When these drift apart you get banding.
+[[skin.derive]]
+var = "--color-hero-background"
+from = "--color-background"
+
+[[skin.derive]]
+var = "--color-nav-background"
+from = "--color-background"
+alpha = 0.9
+
+# One ink colour (confirmed by Alex, who authored this CSS). `.hero .button`
+# fills with --color-hero-text while `.button` fills with --color-button-bg; the
+# two must be the same ink or the hero button diverges from every other button.
+# Both are #000000 in stock. (app-1 has them different — there the hero button
+# sits on a blue band — which is why this coupling is declared per-template
+# rather than assumed.)
+[[skin.derive]]
+var = "--color-hero-text"
+from = "--color-button-bg"
+
+# Hover is a shade of the ink, not an independent colour — otherwise the moment a
+# skin moves --color-button-bg, the hover state is left behind pointing at the old
+# colour. Stock is #161616 on a #000000 button, i.e. a 8.6% LIGHTENING (you cannot
+# darken black). Direction is explicit rather than inferred: app-1's equivalent
+# derive darkens, because its button is a mid blue.
+[[skin.derive]]
+var = "--color-button-hover-bg"
+from = "--color-button-bg"
+lighten = 0.086
+
+# Pairs that must stay legible. These are the rules that actually set both a
+# colour and a background via var() — including the dual-role cases, where a
+# dark page background would otherwise silently yield dark-on-dark button text.
+[[skin.contrast]]
+fg = "--color-text"
+bg = "--color-background"
+min = 4.5
+
+[[skin.contrast]]
+fg = "--color-background"
+bg = "--color-button-bg"
+min = 4.5
+
+[[skin.contrast]]
+fg = "--color-hero-background"
+bg = "--color-hero-text"
+min = 4.5
+
+# Families usable without a loader. A skin naming anything else must also add an
+# @font-face / <link>; the journal batch emitted "Playfair Display" and "Inter"
+# with nothing loading them, so they silently fell back to a generic family.
+[skin.fonts]
+stacks = [
+    "system-ui, sans-serif",
+    "ui-serif, Georgia, serif",
+    "ui-monospace, SFMono-Regular, Menlo, monospace",
+]


### PR DESCRIPTION
Adds a `[skin]` contract declaring what an automated skin pass may change in this template, and what it must not.

**The design questions this PR originally opened with have been answered by Alex, who wrote this CSS — they're baked in below rather than left open.**

## Why

The lead-gen pipeline (`archival-utility preview generate`) runs aider over the template with **unrestricted write access to `public/styles.css`**. On the journal/US batch, **2 of 5 generated sites shipped visibly broken**.

The cause is mechanical, not taste. This template's `:root` encodes **one colour across three variables**:

```css
--color-background:      #f2f2f2;
--color-nav-background:  rgba(242, 242, 242, 0.9);   /* same colour, hand-converted */
--color-hero-background: #f2f2f2;
```

Nothing declared they were related, so the skin re-coloured them independently and the hero split away from the page. Measured by sampling the rendered left margin every 8px: the broken render has **4 band edges** alternating `#f7fafc` / `#e2e8f0`; a stock render has **0** — a uniform `#f2f2f2`.

A second, unfired bug: the variables are **semantically overloaded**. `--color-background` is also the *text* colour on `--color-button-bg` (`.skip-link`, `.support-modules .module a`, `.not-found-cta`), and `--color-hero-background` is the *text* colour on `.hero .button`. A dark background — a perfectly reasonable design choice — silently produces dark-on-dark text. Every model so far happened to pick a light background. That's luck, not safety.

## What this declares

- **`files` / `selector`** — where the styles are. Layout varies across templates (`public/styles.css`, `public/style.css`, `public/styles/global.css`, inline in `theme.liquid`, Tailwind builds), which is *why* the skin was handed freeform file access in the first place. Declaring it removes the guessing.
- **`[skin.variables]`** — the only things a skin may set. Everything else (including all `--spacing-*`) is immutable.
- **`[[skin.derive]]`** — computed, never authored:
  - `--color-hero-background` ← `--color-background`. `header.hero` has no fixed height and only 2.5rem margin-bottom: it is a **continuous page surface**. Divergence = banding.
  - `--color-nav-background` ← `--color-background` at `alpha = 0.9`, removing the hand hex→rgba conversion.
  - `--color-hero-text` ← `--color-button-bg`. **Confirmed as one intentional ink colour**: `.hero .button` fills with the former while `.button` fills with the latter, so they must match or the hero button diverges from every other button.
  - `--color-button-hover-bg` ← `--color-button-bg` at `lighten = 0.086`. Stock `#000000` → `#161616` is exactly an 8.6% lightening, so this describes the template as it already is — and the hover now follows any ink a skin picks instead of being stranded at a stale hex.
- **`[[skin.contrast]]`** — the pairs that must stay legible, including the dual-role cases above.
- **`[skin.fonts]`** — families usable without a loader. The batch emitted `"Playfair Display"` and `"Inter"` while `theme.liquid` was untouched (no `@font-face`, no `<link>`), so they silently fell back.

Direction on the hover derive is explicit (`lighten` here, `darken` in app-1) rather than inferred — an auto-direction rule gets one of them wrong, since you cannot darken black.

## Why app-1's contract is deliberately different

Please read this next to #3. **The invariant is per-template, and assuming otherwise breaks things.**

```css
/* app-2 */  header.hero { padding: 8rem 0 0; margin-bottom: 2.5rem; }
/* app-1 */  header.hero { padding: 8rem 0; margin-bottom: 19rem; height: 43rem; }
```

app-2's hero is a continuous surface, so it must match `--color-background`. app-1's is a deliberate 43rem block, `#184ed8` against `#f9f9f9`. app-1 correctly has **no** such derive — a global "hero must match background" rule would destroy it.

## Verification

`10/10` contract behaviours correct, against this template's real CSS:

- stock app-2 under this contract → clean (incl. the hover derive landing on `#161616` exactly)
- the actual KnownWell desync (`--color-hero-background: #e2e8f0`) → **FAIL derive**
- ink moved but `--color-hero-text` left behind → **FAIL derive**
- a consistent recolour (bg + hero + nav together) → clean
- app-1 stock under app-1's contract → **FAIL**, catching its dead hover (see #3)
- app-1 recoloured with its blue hero untouched → clean *(the exact edit this template's rule would correctly reject)*

Nothing consumes `[skin]` yet — inert metadata until `archival-utility` reads it. `archival_template.schema.json` has no `additionalProperties: false`, so it validates today; `keep_objects` is likewise already used without being declared there.

Proposed reader semantics, which matter: **a declared derive means coupled, a declared variable means free, and silence means "infer conservatively"** — so a partial contract can't lose a check by omission. The lint in `archival-leadgen-scraper` (`scraper lint-previews`) already enforces all of this, inferring invariants from each template's own stock CSS where no contract exists.
