### PR TITLE
app-1: declare a [skin] contract + fix the dead button hover

### DIFF
--- a/archival_template.toml
+++ b/archival_template.toml
@@ -18,3 +18,81 @@ keep_objects = [
     "terms_of_service",
     "privacy_policy"
 ]
+
+# ---------------------------------------------------------------------------
+# Skin contract
+# ---------------------------------------------------------------------------
+# Declares what an automated skin pass may change, and what it must not.
+#
+# Read this alongside app-2's contract — they are deliberately DIFFERENT, and
+# the difference is the point.
+#
+# app-2's `header.hero` has no fixed height and 2.5rem margin-bottom: it is a
+# continuous page surface, so its --color-hero-background MUST derive from
+# --color-background or the two surfaces band apart.
+#
+# app-1's `header.hero` is `height: 43rem; margin-bottom: 19rem` with a
+# deliberate blue (#184ed8) against an off-white (#f9f9f9) page. That contrast
+# is the design. There is therefore NO derive between --color-background and
+# --color-hero-background here, and any tool that assumes one globally is wrong.
+#
+# Anything NOT listed in [skin.variables] is immutable to a skin pass.
+
+[skin]
+files = ["public/styles.css"]
+selector = ":root"
+
+[skin.variables]
+"--color-text" = { type = "color" }
+# NOTE: dual-role — also the text colour on --color-hero-background
+# (.support-modules .module a). The contrast rule below covers that.
+"--color-background" = { type = "color" }
+"--color-hero-background" = { type = "color" }
+"--color-hero-text" = { type = "color" }
+"--color-heading" = { type = "color" }
+"--color-footer-text" = { type = "color" }
+"--color-supplement" = { type = "color" }
+"--typo-h1-size" = { type = "length", min = "3rem", max = "7rem" }
+"--typo-h1-weight" = { type = "number", min = 400, max = 900 }
+"--typo-h2-size" = { type = "length", min = "2rem", max = "5rem" }
+
+# The hero band and the buttons are ONE accent colour (both #184ed8 in stock) —
+# confirmed by Alex, who authored this CSS. Skins set the accent once, via
+# --color-hero-background, and the buttons follow.
+[[skin.derive]]
+var = "--color-button-bg"
+from = "--color-hero-background"
+
+# BUG FIX: --color-button-hover-bg is #184ed8 in stock — identical to
+# --color-button-bg — so buttons currently have NO visible hover change at all.
+# Confirmed a bug, not a choice. Deriving it as a shade fixes the stock template
+# AND holds for any accent a skin picks; a fixed hex would break as soon as the
+# accent moved. `shade` shifts lightness toward the opposite end (darkens light
+# colours, lightens dark ones), matching app-2's stock #000000 -> #161616.
+[[skin.derive]]
+var = "--color-button-hover-bg"
+from = "--color-button-bg"
+darken = 0.08
+
+[[skin.contrast]]
+fg = "--color-text"
+bg = "--color-background"
+min = 4.5
+
+[[skin.contrast]]
+fg = "--color-hero-text"
+bg = "--color-hero-background"
+min = 4.5
+
+# --color-background is used as TEXT on the hero band here.
+[[skin.contrast]]
+fg = "--color-background"
+bg = "--color-hero-background"
+min = 4.5
+
+[skin.fonts]
+stacks = [
+    "system-ui, sans-serif",
+    "ui-serif, Georgia, serif",
+    "ui-monospace, SFMono-Regular, Menlo, monospace",
+]

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,7 +5,7 @@
   --color-background: #f9f9f9;
   --color-heading: #222;
   --color-button-bg: #184ed8;
-  --color-button-hover-bg: #184ed8;
+  --color-button-hover-bg: #1648c7;
   --color-footer-text: #777;
   --color-hero-background: #184ed8;
   --color-supplement: #ffb31a;


### PR DESCRIPTION
Adds a `[skin]` contract declaring what an automated skin pass may change in this template, **and fixes a real bug the contract surfaced: buttons currently have no visible hover state.**

Companion to #2 — please read them together, because they are deliberately different and the difference is the whole point.

**The design questions this PR originally opened with have been answered by Alex, who wrote this CSS — they're baked in below rather than left open.**

## The bug this fixes

```css
--color-button-bg:       #184ed8;
--color-button-hover-bg: #184ed8;   /* identical — hovering a button does nothing */
```

app-2 has `#161616` on `#000000`, i.e. a real (if subtle) shift. Here the two are the same colour, so there is no hover feedback at all. Confirmed a bug, not a choice.

Fixed to `#1648c7` (an 8% darkening) **and** declared as a derive, so it now follows whatever accent a skin picks rather than being left behind at a stale hex — which is how it would have broken again the first time a skin touched the accent.

## Why the contract is needed

The lead-gen pipeline runs aider over the template with **unrestricted write access to `public/styles.css`**. On the journal/US batch (app-2), 2 of 5 sites shipped with the hero banded away from the page, because three variables encoding one colour got desynchronised and nothing declared they were related. app-1 hasn't been through a batch yet; this is preventative.

## The interesting part: app-1's invariants are the *opposite* of app-2's

The obvious fix for app-2 is "make `--color-hero-background` derive from `--color-background`". Applied globally, **that would destroy this template.**

```css
/* app-2 */  header.hero { padding: 8rem 0 0; margin-bottom: 2.5rem; }
/* app-1 */  header.hero { padding: 8rem 0; margin-bottom: 19rem; height: 43rem; }
```

app-2's hero has no fixed height — a continuous page surface, so it *must* match the page colour. app-1's is a deliberate 43rem block, `#184ed8` blue against `#f9f9f9`. **That contrast is the design.** So this contract declares **no derive** between `--color-background` and `--color-hero-background`, and pins the pair with a contrast rule instead.

app-1's actual equality groups, from its own `:root`:

```
#f9f9f9 → { --color-hero-text, --color-background }
#184ed8 → { --color-button-bg, --color-button-hover-bg, --color-hero-background }
```

Its hero colour is tied to its **button** colour, not its page colour — the reverse of app-2.

## What this declares

- **`[[skin.derive]] --color-button-bg ← --color-hero-background`** — **confirmed as one intentional accent**. A skin sets the accent once, via the hero, and the buttons follow.
- **`[[skin.derive]] --color-button-hover-bg ← --color-button-bg` at `darken = 0.08`** — the bug fix above. Direction is explicit (`darken` here, `lighten` in app-2) rather than inferred: an auto-direction rule would get one wrong, since you cannot darken app-2's black button.
- **`[[skin.contrast]]`** — including `--color-background` used as *text* on the hero band (`.support-modules .module a`), a dual-role trap where a bad pairing goes silently unreadable.
- **`[skin.fonts]`** — families usable without a loader.
- `--color-hero-text` and `--color-background` are both `#f9f9f9` but listed as **free**, not coupled: "text on the blue hero" and "page surface" are different roles that happen to share a value here, and the contrast rules cover the visible outcome either way.

## Verification

`10/10` contract behaviours correct, against this template's real CSS:

- **app-1 STOCK → FAIL derive**, catching exactly the dead-hover bug this PR fixes
- app-1 with the fix (`#1648c7`) → clean
- accent recoloured with the hover following → clean
- accent recoloured but hover left stale → **FAIL derive**
- **page recoloured with the blue hero untouched → clean** — the exact edit app-2's rule would wrongly reject, and the reason contracts must be per-template
- unreadable text on the hero band (`#1a3ba8` on `#184ed8`, 1.40:1) → **FAIL contrast**

Nothing consumes `[skin]` yet — inert until `archival-utility` reads it. It validates against `archival_template.schema.json` today (no `additionalProperties: false`; `keep_objects` is likewise already used without being declared there). The CSS hex change is live immediately, and is the one behavioural change in this PR.
