### PR TITLE
app-2: fill app-store link, email, country deterministically

### DIFF
--- a/archival_template.toml
+++ b/archival_template.toml
@@ -118,3 +118,28 @@ stacks = [
     "ui-serif, Georgia, serif",
     "ui-monospace, SFMono-Regular, Menlo, monospace",
 ]
+
+# ---------------------------------------------------------------------------
+# Deterministic field mappings
+# ---------------------------------------------------------------------------
+# These object fields are DATA the generator already holds exactly, not content
+# for the model to compose. archival-utility fills each `object.field` from the
+# named lead-metadata key AFTER generation, overwriting whatever the model
+# produced. The model is not trusted to copy them.
+#
+# Why: the App Store URL is the single most important CTA on the page, and it was
+# being dropped intermittently — the model is asked to copy `app_store_url` into
+# the renamed `appstore_download_link`, while the object prompt tells it twice to
+# leave links empty when unsure (a guard against invented Play Store links). A
+# cautious model takes the hint on the real link too. This makes it a copy, not a
+# request. Same principle as [skin]'s derived variables and keep_objects: compute
+# what we can, don't ask the model for it.
+#
+# A mapping whose metadata key is absent or empty is skipped, leaving the model's
+# value (which the prompt intends to be empty). So playstore/direct download links
+# stay model-controlled — there is no metadata source for them on iOS leads.
+
+[fields]
+"app.appstore_download_link" = "app_store_url"
+"app.legal_email" = "email"
+"app.country" = "country"


### PR DESCRIPTION
Declares which app-2 object fields are **data the generator already holds**, so `archival-utility` fills them from the lead instead of asking the model to.

Pairs with jesseditson/archival-editor's `apply_field_mappings` PR — this is the declaration; that is the code that reads it.

## Why

A generated app site turned up with **no App Store link** — the most important thing on the page. The model is asked to copy `app_store_url` (metadata) into `appstore_download_link` (this object's field, note the rename) and drops it some fraction of the time — ~1 in 3 across a 5-run loop on the same lead. The object-generation prompt also tells it twice to leave links empty when unsure (a guard against invented Play Store links), which nudges a cautious model to blank the real one too.

## What this declares

```toml
[fields]
"app.appstore_download_link" = "app_store_url"
"app.legal_email"            = "email"
"app.country"                = "country"
```

These three are pure data — a URL, an email, a country code — that the scraper already has exactly. The utility overwrites each after generation. Everything else (`name`, `tagline`, `description`, `hero_description`…) stays model-composed, because that *is* content.

Deliberately **not** mapped: `playstore_download_link` and `direct_download_link`. There's no metadata source for them on App Store leads, so the utility skips them and the model leaves them empty — which is correct for an iOS app.

Inert without the utility change; a utility that doesn't understand `[fields]` ignores it (no `deny_unknown_fields`).

## Verification

With the utility change pointed at this branch, the affected lead (Twig) was regenerated 5×: the App Store link and legal email were present on every run, versus ~1 in 3 before.
